### PR TITLE
feat: set up storage that returns a connection pool

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/MungaSoftwiz/org-authenticator-api/config"
+	_ "github.com/lib/pq"
+)
+
+func NewPostgreSQLStorage(cfg config.PostgreSQLConfig) (*sql.DB, error) {
+
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.DBName)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}


### PR DESCRIPTION
The PR closes #4 . It has catered for the tasks below:

- Introduces `NewPostgreSQLStorage` function.
- Constructs PostgreSQL connection string from `config.PostgreSQLConfig`.
- Opens database connection using `sql.Open()`.
- Returns a pointer to the database connection pool `*sql.DB`.