### PR TITLE
feat: create and run an API server

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+
+	"github.com/MungaSoftwiz/org-authenticator-api/service/auth"
+	"github.com/gorilla/mux"
+)
+
+type APIServer struct {
+	addr string
+	db   *sql.DB
+}
+
+func NewAPIServer(addr string, db *sql.DB) *APIServer {
+	return &APIServer{addr: addr, db: db}
+}
+
+func (s *APIServer) Run() error {
+	router := mux.NewRouter()
+	subrouter := router.PathPrefix("/api").Subrouter()
+
+	authHandler := auth.NewHandler()
+	authHandler.RegisterRoutes(subrouter)
+
+	log.Println("Listening on", s.addr)
+	return http.ListenAndServe(s.addr, router)
+}


### PR DESCRIPTION
The PR closes #2 . It resolves the tasks below:

- Adds `APIServer` struct with address and database fields.
- Implements a new server constructor function.
- Defined the run method to start the HTTP server.
- Set up routing with the `mux` library including a subrouter `/api`. **NB:** We might need to version the subrouter in the future.
- Integrate an authentication handler.